### PR TITLE
 Refactor name to use simple file name instead of prefix with project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 The project `ruby-app-deployment-example-project` contains a web server ruby app written in ruby.
 
+# Table of Contents
+
+- [Installation](#installation)
+- [Environment setup](#environment-setup)
+- [How is the Gemfile in the project created?](#how-is-the-gemfile-in-the-project-created)
+- [Running](#running)
+- [Development](#development)
+- [Testing](#testing)
+- [Docker](#docker)
+- [Helm](#helm)
+- [Kind](#kind)
+- [License](#license)
+- [Authors](#authors)
+- [Credits](#credits)
+
 ## Installation
 
 We assume you are using macOS for developing the projects. Below instructions are designed to work in macOS Sonoma 14.0.
@@ -163,3 +178,26 @@ Delete helm chart
 ```
 helm delete ruby-chart
 ```
+
+## Kind
+
+Create a cluster in kind with `config.yaml` file to access the Nodeport service locally
+
+```
+kind create cluster --config=config.yaml
+```
+
+Access the page locally on http://localhost/
+and healthcheck on http://localhost/healthcheck
+
+### License
+
+[LICENSE - GNU GENERAL PUBLIC LICENSE Version 3](LICENSE)
+
+## Authors
+
+[akarsh](https://github.com/akarsh)
+
+### Credits
+
+This project uses Open Source components. You can find the source code of their open source projects along with license information below. We acknowledge and are grateful to these developers for their contributions to open source.

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 30038
+    hostPort: 80

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,24 @@
 version: '3.3'
 services:
-  ruby-app-deployment-example-project:
+  rubyap:
     tty: true
-    ports:
-      - '80:80'
     stdin_open: true
     image: 'sakarsh/ruby-app-deployment-example-project:latest'
+    networks:
+      - rubyap-net
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock'
+  nginx:
+    image: nginx:stable
+    networks:
+      - rubyap-net
+    ports:
+      - '80:80'
+    volumes:
+      - '/var/log/nginx/rubyap'
+      - '$PWD/rubyap.conf:/etc/nginx/conf.d/default.conf'
+      - '/var/run/docker.sock:/var/run/docker.sock'
+    depends_on:
+      - rubyap
+networks:
+  rubyap-net:

--- a/rubyap.conf
+++ b/rubyap.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    server_name rubyap.com;
+
+    location / {
+        proxy_pass http://rubyap:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/rubyap/templates/deployment.yaml
+++ b/rubyap/templates/deployment.yaml
@@ -16,13 +16,9 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        kompose.cmd: kompose convert -f docker-compose.yaml
-        kompose.version: 1.31.2 (HEAD)
       creationTimestamp: null
       labels:
-        io.kompose.network/{{ .Values.container.name }}-default: "true"
-        io.kompose.service: {{ .Values.container.name }}
+        app: {{ .Values.container.name }}
     spec:
       containers:
         - image: sakarsh/{{ .Values.container.name }}:latest
@@ -33,6 +29,6 @@ spec:
               protocol: TCP
           resources: {}
           stdin: true
-          tty: true
+          tty: true 
       restartPolicy: Always
 status: {}

--- a/rubyap/templates/deployment.yaml
+++ b/rubyap/templates/deployment.yaml
@@ -1,18 +1,15 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: kompose convert -f docker-compose.yaml
-    kompose.version: 1.31.2 (HEAD)
   creationTimestamp: null
   labels:
-    io.kompose.service: {{ .Values.container.name }}
-  name: {{ .Values.container.name }}
+    app: {{ .Values.container.name }}
+  name: {{ .Values.container.name }}-deployment
 spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: {{ .Values.container.name }}
+      app: {{ .Values.container.name }}
   strategy: {}
   template:
     metadata:
@@ -25,7 +22,6 @@ spec:
           name: {{ .Values.container.name }}
           ports:
             - containerPort: {{ .Values.container.port }}
-              hostPort: {{ .Values.container.port }}
               protocol: TCP
           resources: {}
           stdin: true

--- a/rubyap/templates/nodeport-service.yml
+++ b/rubyap/templates/nodeport-service.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.container.name }}-nodeport-service
+spec:
+  type: NodePort
+  selector:
+    app: {{ .Values.container.name }}
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+      nodePort: 30038

--- a/rubyap/templates/service.yaml
+++ b/rubyap/templates/service.yaml
@@ -4,14 +4,13 @@ metadata:
   creationTimestamp: null
   labels:
     app: {{ .Values.container.name }}
-  name: {{ .Values.container.name }}
+  name: {{ .Values.container.name }}-service
 spec:
+  type: ClusterIP
   ports:
     - name: "{{ .Values.container.port }}"
       port: {{ .Values.container.port }}
       targetPort: {{ .Values.container.port }}
-      nodePort: 3100
-    type: loadBalancer
   selector:
     app: {{ .Values.container.name }}
 status:

--- a/rubyap/templates/service.yaml
+++ b/rubyap/templates/service.yaml
@@ -1,19 +1,18 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.cmd: kompose convert -f docker-compose.yaml
-    kompose.version: 1.31.2 (HEAD)
   creationTimestamp: null
   labels:
-    io.kompose.service: {{ .Values.container.name }}
+    app: {{ .Values.container.name }}
   name: {{ .Values.container.name }}
 spec:
   ports:
     - name: "{{ .Values.container.port }}"
       port: {{ .Values.container.port }}
       targetPort: {{ .Values.container.port }}
+      nodePort: 3100
+    type: loadBalancer
   selector:
-    io.kompose.service: {{ .Values.container.name }}
+    app: {{ .Values.container.name }}
 status:
   loadBalancer: {}


### PR DESCRIPTION
 - Add nginx as proxy
- Add rubyap.conf file
-  Add config.yaml file for creating kind cluster
- Update README.md with table of contents
   - Add new sections
- Refactor to use app as label
- Refactor to define name for yaml files
- Add new nodeport-service.yaml file

